### PR TITLE
Add `no-headers` option for table output formatting

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 A toolset for inspecting Kubernetes clusters.
 
-Provides SQL interface for querying information about K8s:
+k8s-tools provide a SQL interface for querying information about various Kubernetes resources, including:
 * Containers
 * DaemonSets
 * Deployments
@@ -13,7 +13,31 @@ Provides SQL interface for querying information about K8s:
 * Services
 * StatefulSets
 
+## Features
+
+- SQL-based querying of Kubernetes resources
+- Interactive TUI for database exploration
+- Support for multiple output formats (JSON, Table, Vertical)
+
+## Database Schema
+
+The internal database contains the following schemas:
+
+- `k8s`: Main schema containing all Kubernetes resource tables
+  - `nodes`
+  - `pods`
+  - `deployments`
+  - (etc...)
+
+For detailed schema information, see [DB Documentation](docs/db/index.md)
+
 ## Getting Started
+
+### Prerequisites
+
+- Go 1.23 or later
+- CGO enabled environment
+- Kubernetes cluster access configured
 
 ### Installation
 
@@ -36,11 +60,6 @@ CGO_ENABLED=1 go install github.com/Hexta/k8s-tools/cmd/k8s-tools@latest
     ```shell
     k8s-tools node utilisation -l topology.kubernetes.io/zone=eu-central-1a
     ```
-
-#### Internal DB
-
-k8s-tools can save K8s cluster state in internal DB to ease analyzing.
-[DB Documentation](docs/db/index.md)
 
 1. Init DB.
     ```shell
@@ -65,4 +84,8 @@ k8s-tools can save K8s cluster state in internal DB to ease analyzing.
 
 ## Contributing
 
-Please see our [contributing guidelines](CONTRIBUTING.md).
+Contributions are welcome! Please see our [contributing guidelines](CONTRIBUTING.md).
+
+## License
+
+This project is licensed under the Apache License 2.0.

--- a/cmd/k8s-tools/db.go
+++ b/cmd/k8s-tools/db.go
@@ -28,10 +28,10 @@ func newInitDBCmd() *cobra.Command {
 
 			k8sInfo := k8s.NewInfo(ctx, clientSet)
 			err := k8sInfo.Fetch(fetch.Options{
-				RetryInitialInterval: globalOptions.k8sRetryInitialInterval,
-				RetryJitterPercent:   globalOptions.k8sRetryJitterPercent,
-				RetryMaxAttempts:     globalOptions.k8sRetryMaxAttempts,
-				RetryMaxInterval:     globalOptions.k8sRetryMaxInterval,
+				RetryInitialInterval: globalOptions.K8sRetryInitialInterval,
+				RetryJitterPercent:   globalOptions.K8sRetryJitterPercent,
+				RetryMaxAttempts:     globalOptions.K8sRetryMaxAttempts,
+				RetryMaxInterval:     globalOptions.K8sRetryMaxInterval,
 			})
 			if err != nil {
 				log.Fatalf("Failed to fetch K8s info: %v", err)
@@ -60,7 +60,7 @@ func newQueryDBCmd() *cobra.Command {
 				log.Fatalf("Failed to query DB: %v", err)
 			}
 
-			output, err := format.Apply(globalOptions.Format, data)
+			output, err := format.Apply(globalOptions.Format, globalOptions.FormatOptions, data)
 			if err != nil {
 				log.Fatalf("Failed to format output: %v", err)
 			}

--- a/cmd/k8s-tools/node.go
+++ b/cmd/k8s-tools/node.go
@@ -27,10 +27,10 @@ var nodeUtilisationCmd = &cobra.Command{
 		k8sInfo := k8s.NewInfo(ctx, clientSet)
 		err := k8sInfo.Fetch(fetch.Options{
 			LabelSelector:        nodeCmdOpts.LabelSelector,
-			RetryInitialInterval: globalOptions.k8sRetryInitialInterval,
-			RetryJitterPercent:   globalOptions.k8sRetryJitterPercent,
-			RetryMaxAttempts:     globalOptions.k8sRetryMaxAttempts,
-			RetryMaxInterval:     globalOptions.k8sRetryMaxInterval,
+			RetryInitialInterval: globalOptions.K8sRetryInitialInterval,
+			RetryJitterPercent:   globalOptions.K8sRetryJitterPercent,
+			RetryMaxAttempts:     globalOptions.K8sRetryMaxAttempts,
+			RetryMaxInterval:     globalOptions.K8sRetryMaxInterval,
 		})
 		if err != nil {
 			log.Fatalf("Failed to fetch k8s info: %v", err)

--- a/docs/cli/k8s-tools.md
+++ b/docs/cli/k8s-tools.md
@@ -12,6 +12,7 @@ K8s toolbox
       --k8s-retry-max-attempts uint           Maximum number of attempts for Kubernetes API retry (default 5)
       --k8s-retry-max-interval duration       Maximum interval between retries for Kubernetes API (default 10s)
       --kubeconfig string                     kubeconfig file
+      --no-headers                            do not print headers
   -o, --output Format                         output format (json, table, vertical) (default table)
   -v, --verbose                               verbose
 ```

--- a/docs/cli/k8s-tools_completion.md
+++ b/docs/cli/k8s-tools_completion.md
@@ -23,6 +23,7 @@ See each sub-command's help for details on how to use the generated script.
       --k8s-retry-max-attempts uint           Maximum number of attempts for Kubernetes API retry (default 5)
       --k8s-retry-max-interval duration       Maximum interval between retries for Kubernetes API (default 10s)
       --kubeconfig string                     kubeconfig file
+      --no-headers                            do not print headers
   -o, --output Format                         output format (json, table, vertical) (default table)
   -v, --verbose                               verbose
 ```

--- a/docs/cli/k8s-tools_completion_bash.md
+++ b/docs/cli/k8s-tools_completion_bash.md
@@ -46,6 +46,7 @@ k8s-tools completion bash
       --k8s-retry-max-attempts uint           Maximum number of attempts for Kubernetes API retry (default 5)
       --k8s-retry-max-interval duration       Maximum interval between retries for Kubernetes API (default 10s)
       --kubeconfig string                     kubeconfig file
+      --no-headers                            do not print headers
   -o, --output Format                         output format (json, table, vertical) (default table)
   -v, --verbose                               verbose
 ```

--- a/docs/cli/k8s-tools_completion_fish.md
+++ b/docs/cli/k8s-tools_completion_fish.md
@@ -37,6 +37,7 @@ k8s-tools completion fish [flags]
       --k8s-retry-max-attempts uint           Maximum number of attempts for Kubernetes API retry (default 5)
       --k8s-retry-max-interval duration       Maximum interval between retries for Kubernetes API (default 10s)
       --kubeconfig string                     kubeconfig file
+      --no-headers                            do not print headers
   -o, --output Format                         output format (json, table, vertical) (default table)
   -v, --verbose                               verbose
 ```

--- a/docs/cli/k8s-tools_completion_powershell.md
+++ b/docs/cli/k8s-tools_completion_powershell.md
@@ -34,6 +34,7 @@ k8s-tools completion powershell [flags]
       --k8s-retry-max-attempts uint           Maximum number of attempts for Kubernetes API retry (default 5)
       --k8s-retry-max-interval duration       Maximum interval between retries for Kubernetes API (default 10s)
       --kubeconfig string                     kubeconfig file
+      --no-headers                            do not print headers
   -o, --output Format                         output format (json, table, vertical) (default table)
   -v, --verbose                               verbose
 ```

--- a/docs/cli/k8s-tools_completion_zsh.md
+++ b/docs/cli/k8s-tools_completion_zsh.md
@@ -48,6 +48,7 @@ k8s-tools completion zsh [flags]
       --k8s-retry-max-attempts uint           Maximum number of attempts for Kubernetes API retry (default 5)
       --k8s-retry-max-interval duration       Maximum interval between retries for Kubernetes API (default 10s)
       --kubeconfig string                     kubeconfig file
+      --no-headers                            do not print headers
   -o, --output Format                         output format (json, table, vertical) (default table)
   -v, --verbose                               verbose
 ```

--- a/docs/cli/k8s-tools_db.md
+++ b/docs/cli/k8s-tools_db.md
@@ -17,6 +17,7 @@ DB with K8s information
       --k8s-retry-max-attempts uint           Maximum number of attempts for Kubernetes API retry (default 5)
       --k8s-retry-max-interval duration       Maximum interval between retries for Kubernetes API (default 10s)
       --kubeconfig string                     kubeconfig file
+      --no-headers                            do not print headers
   -o, --output Format                         output format (json, table, vertical) (default table)
   -v, --verbose                               verbose
 ```

--- a/docs/cli/k8s-tools_db_init.md
+++ b/docs/cli/k8s-tools_db_init.md
@@ -21,6 +21,7 @@ k8s-tools db init [flags]
       --k8s-retry-max-attempts uint           Maximum number of attempts for Kubernetes API retry (default 5)
       --k8s-retry-max-interval duration       Maximum interval between retries for Kubernetes API (default 10s)
       --kubeconfig string                     kubeconfig file
+      --no-headers                            do not print headers
   -o, --output Format                         output format (json, table, vertical) (default table)
   -v, --verbose                               verbose
 ```

--- a/docs/cli/k8s-tools_db_query.md
+++ b/docs/cli/k8s-tools_db_query.md
@@ -27,6 +27,7 @@ query "SELECT * FROM k8s.nodes LIMIT 10"
       --k8s-retry-max-attempts uint           Maximum number of attempts for Kubernetes API retry (default 5)
       --k8s-retry-max-interval duration       Maximum interval between retries for Kubernetes API (default 10s)
       --kubeconfig string                     kubeconfig file
+      --no-headers                            do not print headers
   -o, --output Format                         output format (json, table, vertical) (default table)
   -v, --verbose                               verbose
 ```

--- a/docs/cli/k8s-tools_db_tui.md
+++ b/docs/cli/k8s-tools_db_tui.md
@@ -21,6 +21,7 @@ k8s-tools db tui [flags]
       --k8s-retry-max-attempts uint           Maximum number of attempts for Kubernetes API retry (default 5)
       --k8s-retry-max-interval duration       Maximum interval between retries for Kubernetes API (default 10s)
       --kubeconfig string                     kubeconfig file
+      --no-headers                            do not print headers
   -o, --output Format                         output format (json, table, vertical) (default table)
   -v, --verbose                               verbose
 ```

--- a/docs/cli/k8s-tools_docs.md
+++ b/docs/cli/k8s-tools_docs.md
@@ -17,6 +17,7 @@ Documentation for k8s-tools
       --k8s-retry-max-attempts uint           Maximum number of attempts for Kubernetes API retry (default 5)
       --k8s-retry-max-interval duration       Maximum interval between retries for Kubernetes API (default 10s)
       --kubeconfig string                     kubeconfig file
+      --no-headers                            do not print headers
   -o, --output Format                         output format (json, table, vertical) (default table)
   -v, --verbose                               verbose
 ```

--- a/docs/cli/k8s-tools_docs_generate.md
+++ b/docs/cli/k8s-tools_docs_generate.md
@@ -21,6 +21,7 @@ k8s-tools docs generate [output dir] [flags]
       --k8s-retry-max-attempts uint           Maximum number of attempts for Kubernetes API retry (default 5)
       --k8s-retry-max-interval duration       Maximum interval between retries for Kubernetes API (default 10s)
       --kubeconfig string                     kubeconfig file
+      --no-headers                            do not print headers
   -o, --output Format                         output format (json, table, vertical) (default table)
   -v, --verbose                               verbose
 ```

--- a/docs/cli/k8s-tools_node.md
+++ b/docs/cli/k8s-tools_node.md
@@ -17,6 +17,7 @@ K8s node tools
       --k8s-retry-max-attempts uint           Maximum number of attempts for Kubernetes API retry (default 5)
       --k8s-retry-max-interval duration       Maximum interval between retries for Kubernetes API (default 10s)
       --kubeconfig string                     kubeconfig file
+      --no-headers                            do not print headers
   -o, --output Format                         output format (json, table, vertical) (default table)
   -v, --verbose                               verbose
 ```

--- a/docs/cli/k8s-tools_node_utilisation.md
+++ b/docs/cli/k8s-tools_node_utilisation.md
@@ -22,6 +22,7 @@ k8s-tools node utilisation [flags]
       --k8s-retry-max-attempts uint           Maximum number of attempts for Kubernetes API retry (default 5)
       --k8s-retry-max-interval duration       Maximum interval between retries for Kubernetes API (default 10s)
       --kubeconfig string                     kubeconfig file
+      --no-headers                            do not print headers
   -o, --output Format                         output format (json, table, vertical) (default table)
   -v, --verbose                               verbose
 ```

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/Hexta/k8s-tools
 
-go 1.23.4
+go 1.23.5
 
 require (
 	github.com/DATA-DOG/go-sqlmock v1.5.2

--- a/internal/db/duckdb/tui.go
+++ b/internal/db/duckdb/tui.go
@@ -121,7 +121,7 @@ func (m model) handleKeyEnter() string {
 		return fmt.Sprintf("ERROR: %v", err)
 	}
 
-	return format.Table(result)
+	return format.Table(result, format.Options{})
 }
 
 func (m model) View() string {

--- a/internal/format/format.go
+++ b/internal/format/format.go
@@ -4,6 +4,10 @@ import "fmt"
 
 type Format string
 
+type Options struct {
+	NoHeaders bool
+}
+
 const (
 	JSONFormat     = "json"
 	TableFormat    = "table"
@@ -28,12 +32,12 @@ func (f *Format) Type() string {
 	return "Format"
 }
 
-func Apply(format Format, input *Data) (string, error) {
+func Apply(format Format, options Options, input *Data) (string, error) {
 	switch format {
 	case JSONFormat:
 		return JSON(input), nil
 	case TableFormat:
-		return Table(input), nil
+		return Table(input, options), nil
 	case VerticalFormat:
 		return Vertical(input), nil
 	default:

--- a/internal/format/table.go
+++ b/internal/format/table.go
@@ -7,9 +7,17 @@ import (
 	"github.com/rodaine/table"
 )
 
-func Table(input *Data) string {
+func Table(input *Data, options Options) string {
 	var buf bytes.Buffer
-	tbl := table.New(input.columns...).WithWriter(&buf).WithHeaderSeparatorRow('_')
+	var tbl table.Table
+
+	if options.NoHeaders {
+		// Create a table without headers.
+		tbl = table.New(input.columns...).WithWriter(&buf).WithPrintHeaders(false)
+	} else {
+		// Create a table with headers and set a separator row.
+		tbl = table.New(input.columns...).WithWriter(&buf).WithHeaderSeparatorRow('_')
+	}
 
 	for _, row := range input.rows {
 		tbl.AddRow(row...)


### PR DESCRIPTION
Introduce a new `--no-headers` flag to suppress table headers in CLI output.
